### PR TITLE
Fix console clearing

### DIFF
--- a/game/game.go
+++ b/game/game.go
@@ -3,9 +3,6 @@ package game
 import (
 	"GitHub/GameOfLife/gameOfLife"
 	"fmt"
-	"os"
-	"os/exec"
-	"runtime"
 	"strings"
 	"time"
 )
@@ -40,16 +37,9 @@ func (g *Game) Run() error {
 }
 
 func clearConsole() {
-	switch runtime.GOOS {
-	case "darwin", "linux":
-		cmd := exec.Command("clear")
-		cmd.Stdout = os.Stdout
-		cmd.Run()
-	case "windows":
-		cmd := exec.Command("cmd", "/c", "cls")
-		cmd.Stdout = os.Stdout
-		cmd.Run()
-	}
+	// use ANSI escape codes which work on most terminals instead of relying
+	// on external commands like `clear` or `cls`
+	fmt.Print("\033[H\033[2J")
 }
 
 func (g *Game) Draw() {


### PR DESCRIPTION
## Summary
- fix console clearing by using ANSI escape codes

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f5cb2e9a08328ae3ec3e17f6cb6d1