### PR TITLE
Fix density panic in NewWorld

### DIFF
--- a/gameOfLife/world.go
+++ b/gameOfLife/world.go
@@ -12,6 +12,10 @@ type World struct {
 }
 
 func NewWorld(width, height, density int) *World {
+	if density >= 12 {
+		density = 11
+	}
+
 	rand.Seed(time.Now().UnixNano())
 	cells := make([][]Cell, height)
 

--- a/gameOfLife/world_test.go
+++ b/gameOfLife/world_test.go
@@ -1,0 +1,15 @@
+package gameOfLife
+
+import "testing"
+
+func TestNewWorldHighDensityNoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("NewWorld panicked with high density: %v", r)
+		}
+	}()
+	w := NewWorld(5, 5, 20)
+	if w == nil {
+		t.Fatal("NewWorld returned nil")
+	}
+}


### PR DESCRIPTION
## Summary
- prevent negative `rand.Intn` by clamping density >= 12
- add regression test ensuring large densities don't panic

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840aa1eee608328a54ebcaba656b7c4